### PR TITLE
Scheduling limitation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This component is part of the Vaadin Component Factory.
   
 - Scheduling Assistant Plugin (*):
   - Conflict detection and available time slot visualization
+  - The Scheduling Assistant can only be used with Hourly View. 
 
 - Full Event Listener Support:
   - Event click handling (CalendarEventClickEvent)

--- a/vcf-schedule-x/src/main/java/org/vaadin/addons/componentfactory/schedulexcalendar/ScheduleXResourceScheduler.java
+++ b/vcf-schedule-x/src/main/java/org/vaadin/addons/componentfactory/schedulexcalendar/ScheduleXResourceScheduler.java
@@ -67,6 +67,14 @@ public class ScheduleXResourceScheduler extends BaseScheduleXCalendar {
       Map<String, Calendar> calendars, ResourceSchedulerConfig resourceSchedulerConfig,
       SchedulingAssistantConfig schedulingAssistantConfig) {
     this(views, dataProvider, configuration, calendars, resourceSchedulerConfig);
+    
+    if (ResourceViewType.DAILY.equals(this.getView())
+        && schedulingAssistantConfig != null) {
+      throw new IllegalArgumentException(
+          "Scheduling Assistant is not supported with ResourceViewType.DAILY. "
+              + "Use an ResourceViewType.HOURLY view instead.");
+    }
+   
     this.schedulingAssistantConfig = schedulingAssistantConfig;
     this.schedulingAssistantConfig.setCalendar(this);
   }

--- a/vcf-schedule-x/src/main/java/org/vaadin/addons/componentfactory/schedulexcalendar/SchedulingAssistantConfig.java
+++ b/vcf-schedule-x/src/main/java/org/vaadin/addons/componentfactory/schedulexcalendar/SchedulingAssistantConfig.java
@@ -22,6 +22,10 @@ import org.vaadin.addons.componentfactory.schedulexcalendar.util.DateTimeFormatU
 
 /**
  * Java model representing the SchedulingAssistant plugin config.
+ * 
+ * <p>
+ * <b>Note:</b> The {@link SchedulingAssistantConfig} can only be used with
+ * {@link ResourceView.HOURLY}.
  */
 @SuppressWarnings("serial")
 public class SchedulingAssistantConfig extends BaseConfiguration implements Serializable {


### PR DESCRIPTION
The scheduling assistant only supports hourly view. Constructor was updates to throw an exception when attempting to initialize with a daily view to avoid endless loops.

Also documentation was updated to highlight this limitation.