### PR TITLE
Fixed: illegally reassigned const was changed to local let variable

### DIFF
--- a/vcf-schedule-x/src/main/resources/META-INF/resources/frontend/src/vcf-schedule-x-resource-scheduler.js
+++ b/vcf-schedule-x/src/main/resources/META-INF/resources/frontend/src/vcf-schedule-x-resource-scheduler.js
@@ -145,13 +145,13 @@ window.vcfschedulexresourcescheduler = {
 		this._assignIfExists(resourceConfig, parsed, 'highlightToday');
 		this._assignIfExists(resourceConfig, parsed, 'dayNameFormat');
 		this._assignIfExists(resourceConfig, parsed, 'initialHours', raw => {
-			const [start, end] = this._parseInitialRange(raw);
+			let [start, end] = this._parseInitialRange(raw);
 			start = Temporal.PlainDateTime.from(start);
 			end = Temporal.PlainDateTime.from(end);
 			return timeUnits.getDayHoursBetween(start, end);
 		});
 		this._assignIfExists(resourceConfig, parsed, 'initialDays', raw => {
-			const [start, end] = this._parseInitialRange(raw);
+			let [start, end] = this._parseInitialRange(raw);
 			start = Temporal.PlainDate.from(start);
 			end = Temporal.PlainDate.from(end);
 			return timeUnits.getDaysBetween(start, end);


### PR DESCRIPTION
Problem:
- illegally reassigned const led to dev build issues

Expected behavior:
- dev build should run successfully without being interrupted by trying to parse illegal js

Fix:
- const was changed to local let variable

Fixes: https://github.com/vaadin-component-factory/vcf-schedule-x/issues/13 if pushed to vaadin addon maven repo
