### PR TITLE
Update logic to dynamically update dark mode after view change

### DIFF
--- a/vcf-schedule-x/src/main/java/org/vaadin/addons/componentfactory/schedulexcalendar/Configuration.java
+++ b/vcf-schedule-x/src/main/java/org/vaadin/addons/componentfactory/schedulexcalendar/Configuration.java
@@ -186,8 +186,10 @@ public class Configuration extends BaseConfiguration implements Serializable {
   }
 
   public void setDark(boolean isDark) {
+    if (this.getCalendar() != null) {
+      this.getCalendar().setDarkMode(isDark);
+    }
     this.isDark = isDark;
-    this.runRefresh();
   }
 
   public DayBoundaries getDayBoundaries() {

--- a/vcf-schedule-x/src/main/resources/META-INF/resources/frontend/src/vcf-schedule-x-calendar.js
+++ b/vcf-schedule-x/src/main/resources/META-INF/resources/frontend/src/vcf-schedule-x-calendar.js
@@ -74,23 +74,31 @@ window.vcfschedulexcalendar = {
 	          // (Optional) configure the intervals, in minutes, at which a time grid-event can be drawn. Valid values: 15, 30, 60
 	          snapDuration: drawSnapDuration
 	        });	
-	        setTimeout(() =>
-	            createCommonCalendar(container, viewFactoryMap, parsedConfig, calendarsJson, {
-	                viewsJson,
-	                drawPlugin
-	            })
+	        setTimeout(() => {
+		            createCommonCalendar(container, viewFactoryMap, parsedConfig, calendarsJson, {
+		                viewsJson,
+		                drawPlugin
+		            });
+					
+					if(currentViewJson){
+						this.setView(container,currentViewJson);
+					};       
+				
+				}
+				
         	);		
 		} else {
-			 setTimeout(() =>
-	            createCommonCalendar(container, viewFactoryMap, parsedConfig, calendarsJson, {
-	                viewsJson
-	            })
+			 setTimeout(() => {
+		            createCommonCalendar(container, viewFactoryMap, parsedConfig, calendarsJson, {
+		                viewsJson
+		            });
+					if(currentViewJson){
+						this.setView(container,currentViewJson);
+					};   			
+				}
 	        );
 		}
 		
-		if(currentViewJson){
-			this.setView(container,currentViewJson);
-		}       
 	},
 
 	setView(container, view) {


### PR DESCRIPTION
This was reported in support request. After changing the view away from the defaultView, and trying to chaneg the view to dark mode, some console error appeared. The problem was the logic updating the dark mode, it should use a dynamic update approach instead of triggering a full calendar refresh, similar to the other properties of the configuration. 
